### PR TITLE
fix(signer): use yParity for typed transactions and pass signature as serializer arg

### DIFF
--- a/src/gcp/signer.ts
+++ b/src/gcp/signer.ts
@@ -9,6 +9,7 @@ import type {
 import {
 	concat,
 	fromHex,
+	getTransactionType,
 	hashMessage,
 	hashTypedData,
 	keccak256,
@@ -20,6 +21,8 @@ import { extractPublicKeyFromDer, publicKeyToAddress } from '../utils/address';
 import { parseDerSignature } from '../utils/der';
 import {
 	calculateRecoveryId,
+	calculateV,
+	calculateYParity,
 	normalizeS,
 	uint8ArrayToBigInt,
 } from '../utils/signature';
@@ -256,12 +259,15 @@ export class GcpSigner {
 			serializer = serializeTransaction,
 		}: { serializer?: SerializeTransactionFn } = {},
 	): Promise<Hex> {
-		// Serialize transaction for signing (without r, s, v)
+		// Strip signature-related fields (including yParity) before hashing
+		// so the unsigned payload is hashed deterministically regardless of
+		// whether the caller left stray fields on the input.
 		const serializedTx = serializeTransaction({
 			...transaction,
 			r: undefined,
 			s: undefined,
 			v: undefined,
+			yParity: undefined,
 		});
 		const hash = keccak256(serializedTx);
 
@@ -277,18 +283,29 @@ export class GcpSigner {
 			address,
 		);
 
-		// Calculate v value
-		const chainId = transaction.chainId;
-		const v = chainId
-			? BigInt(chainId * 2 + 35 + recoveryId) // EIP-155
-			: BigInt(27 + recoveryId); // Legacy
+		// Typed transactions (EIP-2930/1559/4844/7702) require `yParity`.
+		// Only legacy (type 0) transactions use the EIP-155 / pre-EIP-155 `v`.
+		// The signature must be passed as the second argument to viem's
+		// serializer — `serializeTransactionLegacy` ignores r/s/v spread
+		// onto the transaction object.
+		const transactionType = getTransactionType(transaction);
+		const rHex = toHex(r, { size: 32 });
+		const sHex = toHex(s, { size: 32 });
 
-		// Final serialization with signature
-		return serializer({
-			...transaction,
-			r: toHex(r, { size: 32 }),
-			s: toHex(s, { size: 32 }),
-			v,
+		if (transactionType === 'legacy') {
+			const chainId = transaction.chainId;
+			const v =
+				chainId !== undefined
+					? calculateV(recoveryId, chainId)
+					: calculateV(recoveryId);
+
+			return serializer(transaction, { r: rHex, s: sHex, v });
+		}
+
+		return serializer(transaction, {
+			r: rHex,
+			s: sHex,
+			yParity: calculateYParity(recoveryId),
 		});
 	}
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,332 @@
+import type { TransactionSerializable } from 'viem';
+import {
+	fromHex,
+	getAddress,
+	parseTransaction,
+	recoverTransactionAddress,
+} from 'viem';
+import {
+	generatePrivateKey,
+	privateKeyToAccount,
+	sign as viemSign,
+} from 'viem/accounts';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { GcpClient } from './gcp/client';
+import { GcpSigner } from './gcp/signer';
+import { KmsClient } from './kms/client';
+import { KmsSigner } from './kms/signer';
+
+vi.mock('./kms/client', () => ({ KmsClient: vi.fn() }));
+vi.mock('./gcp/client', () => ({ GcpClient: vi.fn() }));
+
+// ASN.1 DER encoder for a secp256k1 ECDSA signature (SEQUENCE { INTEGER r, INTEGER s }).
+// Mirrors what AWS/GCP KMS returns so tests can feed real viem-produced signatures
+// through the production DER parser path.
+function encodeDerInteger(value: Uint8Array): Uint8Array {
+	let start = 0;
+	while (start < value.length - 1 && value[start] === 0) start++;
+	let body = value.slice(start);
+	if ((body[0] & 0x80) !== 0) {
+		const padded = new Uint8Array(body.length + 1);
+		padded[0] = 0x00;
+		padded.set(body, 1);
+		body = padded;
+	}
+	const header = new Uint8Array([0x02, body.length]);
+	const out = new Uint8Array(header.length + body.length);
+	out.set(header, 0);
+	out.set(body, header.length);
+	return out;
+}
+
+function bigintToBytes32(value: bigint): Uint8Array {
+	const hex = value.toString(16).padStart(64, '0');
+	const bytes = new Uint8Array(32);
+	for (let i = 0; i < 32; i++) {
+		bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	}
+	return bytes;
+}
+
+function encodeDerSignature(r: bigint, s: bigint): Uint8Array {
+	const rDer = encodeDerInteger(bigintToBytes32(r));
+	const sDer = encodeDerInteger(bigintToBytes32(s));
+	const content = new Uint8Array(rDer.length + sDer.length);
+	content.set(rDer, 0);
+	content.set(sDer, rDer.length);
+	const out = new Uint8Array(content.length + 2);
+	out[0] = 0x30;
+	out[1] = content.length;
+	out.set(content, 2);
+	return out;
+}
+
+function setupRealCryptoMock(
+	clientMock: ReturnType<typeof vi.fn>,
+	privateKey: `0x${string}`,
+) {
+	const account = privateKeyToAccount(privateKey);
+	const publicKeyBytes = fromHex(account.publicKey, 'bytes');
+
+	clientMock.mockImplementation(function (this: {
+		getPublicKey: () => Promise<Uint8Array>;
+		sign: (hash: Uint8Array) => Promise<Uint8Array>;
+	}) {
+		this.getPublicKey = async () => publicKeyBytes;
+		this.sign = async (hash: Uint8Array) => {
+			const hashHex = `0x${Array.from(hash)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('')}` as `0x${string}`;
+			const sig = await viemSign({
+				hash: hashHex,
+				privateKey,
+				to: 'object',
+			});
+			const r = BigInt(sig.r);
+			const s = BigInt(sig.s);
+			return encodeDerSignature(r, s);
+		};
+		return this;
+	});
+
+	return account;
+}
+
+describe('signTransaction yParity round-trip (issue #98)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('KmsSigner', () => {
+		test('EIP-1559 typed transaction recovers to signer address', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(KmsClient), privateKey);
+			const signer = new KmsSigner({
+				region: 'us-east-1',
+				keyId: 'test-key',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip1559',
+				chainId: 11155111,
+				nonce: 18,
+				maxFeePerGas: 12_090_378n,
+				maxPriorityFeePerGas: 1_000_000n,
+				gas: 59_850n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				data: '0x',
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip1559');
+			expect(parsed.yParity === 0 || parsed.yParity === 1).toBe(true);
+		});
+
+		test('EIP-2930 typed transaction recovers to signer address', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(KmsClient), privateKey);
+			const signer = new KmsSigner({
+				region: 'us-east-1',
+				keyId: 'test-key',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip2930',
+				chainId: 1,
+				nonce: 0,
+				gasPrice: 20_000_000_000n,
+				gas: 21_000n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				accessList: [],
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip2930');
+		});
+
+		test('legacy EIP-155 transaction recovers to signer address (regression)', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(KmsClient), privateKey);
+			const signer = new KmsSigner({
+				region: 'us-east-1',
+				keyId: 'test-key',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'legacy',
+				chainId: 1,
+				nonce: 0,
+				gasPrice: 20_000_000_000n,
+				gas: 21_000n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 1n,
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('legacy');
+			// EIP-155: v = chainId * 2 + 35 + recoveryId, so v ∈ {37, 38} for chainId 1
+			expect(parsed.v === 37n || parsed.v === 38n).toBe(true);
+		});
+
+		test('legacy transaction without chainId recovers to signer address (pre-EIP-155)', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(KmsClient), privateKey);
+			const signer = new KmsSigner({
+				region: 'us-east-1',
+				keyId: 'test-key',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'legacy',
+				nonce: 0,
+				gasPrice: 20_000_000_000n,
+				gas: 21_000n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 1n,
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.v === 27n || parsed.v === 28n).toBe(true);
+		});
+	});
+
+	describe('GcpSigner', () => {
+		test('EIP-1559 typed transaction recovers to signer address', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(GcpClient), privateKey);
+			const signer = new GcpSigner({
+				projectId: 'test-project',
+				locationId: 'global',
+				keyRingId: 'test-keyring',
+				keyId: 'test-key',
+				keyVersion: '1',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip1559',
+				chainId: 11155111,
+				nonce: 18,
+				maxFeePerGas: 12_090_378n,
+				maxPriorityFeePerGas: 1_000_000n,
+				gas: 59_850n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				data: '0x',
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip1559');
+			expect(parsed.yParity === 0 || parsed.yParity === 1).toBe(true);
+		});
+
+		test('EIP-2930 typed transaction recovers to signer address', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(GcpClient), privateKey);
+			const signer = new GcpSigner({
+				projectId: 'test-project',
+				locationId: 'global',
+				keyRingId: 'test-keyring',
+				keyId: 'test-key',
+				keyVersion: '1',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip2930',
+				chainId: 1,
+				nonce: 0,
+				gasPrice: 20_000_000_000n,
+				gas: 21_000n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				accessList: [],
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip2930');
+		});
+
+		test('legacy EIP-155 transaction recovers to signer address (regression)', async () => {
+			// #given
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(GcpClient), privateKey);
+			const signer = new GcpSigner({
+				projectId: 'test-project',
+				locationId: 'global',
+				keyRingId: 'test-keyring',
+				keyId: 'test-key',
+				keyVersion: '1',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'legacy',
+				chainId: 1,
+				nonce: 0,
+				gasPrice: 20_000_000_000n,
+				gas: 21_000n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 1n,
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('legacy');
+			expect(parsed.v === 37n || parsed.v === 38n).toBe(true);
+		});
+	});
+});

--- a/src/kms/signer.ts
+++ b/src/kms/signer.ts
@@ -9,6 +9,7 @@ import type {
 import {
 	concat,
 	fromHex,
+	getTransactionType,
 	hashMessage,
 	hashTypedData,
 	keccak256,
@@ -20,6 +21,8 @@ import { extractPublicKeyFromDer, publicKeyToAddress } from '../utils/address';
 import { parseDerSignature } from '../utils/der';
 import {
 	calculateRecoveryId,
+	calculateV,
+	calculateYParity,
 	normalizeS,
 	uint8ArrayToBigInt,
 } from '../utils/signature';
@@ -243,12 +246,15 @@ export class KmsSigner {
 			serializer = serializeTransaction,
 		}: { serializer?: SerializeTransactionFn } = {},
 	): Promise<Hex> {
-		// Serialize transaction for signing (without r, s, v)
+		// Strip signature-related fields (including yParity) before hashing
+		// so the unsigned payload is hashed deterministically regardless of
+		// whether the caller left stray fields on the input.
 		const serializedTx = serializeTransaction({
 			...transaction,
 			r: undefined,
 			s: undefined,
 			v: undefined,
+			yParity: undefined,
 		});
 		const hash = keccak256(serializedTx);
 
@@ -264,18 +270,29 @@ export class KmsSigner {
 			address,
 		);
 
-		// Calculate v value
-		const chainId = transaction.chainId;
-		const v = chainId
-			? BigInt(chainId * 2 + 35 + recoveryId) // EIP-155
-			: BigInt(27 + recoveryId); // Legacy
+		// Typed transactions (EIP-2930/1559/4844/7702) require `yParity`.
+		// Only legacy (type 0) transactions use the EIP-155 / pre-EIP-155 `v`.
+		// The signature must be passed as the second argument to viem's
+		// serializer — `serializeTransactionLegacy` ignores r/s/v spread
+		// onto the transaction object.
+		const transactionType = getTransactionType(transaction);
+		const rHex = toHex(r, { size: 32 });
+		const sHex = toHex(s, { size: 32 });
 
-		// Final serialization with signature
-		return serializer({
-			...transaction,
-			r: toHex(r, { size: 32 }),
-			s: toHex(s, { size: 32 }),
-			v,
+		if (transactionType === 'legacy') {
+			const chainId = transaction.chainId;
+			const v =
+				chainId !== undefined
+					? calculateV(recoveryId, chainId)
+					: calculateV(recoveryId);
+
+			return serializer(transaction, { r: rHex, s: sHex, v });
+		}
+
+		return serializer(transaction, {
+			r: rHex,
+			s: sHex,
+			yParity: calculateYParity(recoveryId),
 		});
 	}
 

--- a/src/utils/signature.test.ts
+++ b/src/utils/signature.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	calculateRecoveryId,
 	calculateV,
+	calculateYParity,
 	normalizeS,
 	SECP256K1_N,
 	SECP256K1_N_HALF,
@@ -394,6 +395,74 @@ describe('calculateV - additional failure cases', () => {
 		// #then
 		// v = 11155111 * 2 + 35 + 3 = 22310260
 		expect(v).toBe(22310260n);
+	});
+});
+
+describe('calculateYParity', () => {
+	test('should return 0 for recoveryId 0', () => {
+		// #given
+		const recoveryId = 0;
+
+		// #when
+		const yParity = calculateYParity(recoveryId);
+
+		// #then
+		expect(yParity).toBe(0);
+	});
+
+	test('should return 1 for recoveryId 1', () => {
+		// #given
+		const recoveryId = 1;
+
+		// #when
+		const yParity = calculateYParity(recoveryId);
+
+		// #then
+		expect(yParity).toBe(1);
+	});
+
+	test('should return 0 for recoveryId 2', () => {
+		// #given
+		const recoveryId = 2;
+
+		// #when
+		const yParity = calculateYParity(recoveryId);
+
+		// #then
+		expect(yParity).toBe(0);
+	});
+
+	test('should return 1 for recoveryId 3', () => {
+		// #given
+		const recoveryId = 3;
+
+		// #when
+		const yParity = calculateYParity(recoveryId);
+
+		// #then
+		expect(yParity).toBe(1);
+	});
+
+	test('should throw RecoveryIdCalculationError when recoveryId < 0', () => {
+		// #given
+		const recoveryId = -1;
+
+		// #when & #then
+		expect(() => calculateYParity(recoveryId)).toThrow(
+			RecoveryIdCalculationError,
+		);
+		expect(() => calculateYParity(recoveryId)).toThrow('Invalid recovery ID');
+	});
+
+	test('should throw RecoveryIdCalculationError when recoveryId > 3', () => {
+		// #given
+		const recoveryId = 4;
+
+		// #when & #then
+		expect(() => calculateYParity(recoveryId)).toThrow(
+			RecoveryIdCalculationError,
+		);
+		expect(() => calculateYParity(recoveryId)).toThrow('Invalid recovery ID');
 	});
 });
 

--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -123,6 +123,12 @@ export async function calculateRecoveryId(
  * @param chainId - Optional chain ID for EIP-155 signatures
  * @returns The v value as bigint
  *
+ * @remarks
+ * This is only valid for legacy (type 0) transactions and EIP-191 / EIP-712
+ * signatures. Typed transactions (EIP-2930, EIP-1559, EIP-4844, EIP-7702)
+ * encode the parity bit as `yParity`, not as an EIP-155 `v`. Use
+ * {@link calculateYParity} for those.
+ *
  * @example
  * ```typescript
  * // Legacy signature (no chain ID)
@@ -146,6 +152,35 @@ export function calculateV(recoveryId: number, chainId?: number): bigint {
 
 	// Legacy: v = 27 + recoveryId
 	return BigInt(27 + recoveryId);
+}
+
+/**
+ * Calculates the yParity value for a typed transaction signature.
+ *
+ * Typed Ethereum transactions (EIP-2930, EIP-1559, EIP-4844, EIP-7702) encode
+ * the recovery bit as `yParity` (0 or 1) instead of the legacy EIP-155 `v`.
+ * The yParity is derived from the recovery id modulo 2.
+ *
+ * @param recoveryId - The recovery ID (0-3)
+ * @returns The yParity value (0 or 1)
+ * @throws {RecoveryIdCalculationError} If recoveryId is out of range
+ *
+ * @example
+ * ```typescript
+ * calculateYParity(0) // returns 0
+ * calculateYParity(1) // returns 1
+ * calculateYParity(2) // returns 0
+ * calculateYParity(3) // returns 1
+ * ```
+ */
+export function calculateYParity(recoveryId: number): 0 | 1 {
+	if (recoveryId < 0 || recoveryId > 3) {
+		throw new RecoveryIdCalculationError(
+			`Invalid recovery ID (must be 0-3): ${recoveryId}`,
+		);
+	}
+
+	return (recoveryId % 2) as 0 | 1;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #98.

Both `GcpSigner.signTransaction` and `KmsSigner.signTransaction` always built an EIP-155 `v` whenever a `chainId` was set. That formula is only valid for legacy (type 0) transactions. EIP-2930, EIP-1559, EIP-4844 and EIP-7702 transactions encode the recovery bit as **`yParity`** (0 | 1). Feeding the wrong field into viem's typed serializer produces the wrong parity in the final RLP, so `recoverTransactionAddress(serializedTx)` returns a different address than the KMS key — and `eth_sendRawTransaction` fails with `insufficient funds` on the unrelated recovered signer.

While fixing this I also found a second, latent bug along the same code path: both signers spread `r/s/v` onto the transaction object and let viem pick them up. Typed serializers do that via `signature_ ?? transaction` inside `toYParitySignatureArray`, but `serializeTransactionLegacy(transaction, signature)` does **not** — it only reads its second `signature` argument. So `type: 'legacy'` outputs silently dropped the signature and produced an unsigned EIP-155 RLP. The typed path happened to work but only incidentally. The fix passes the signature as the second argument in both branches.

## Changes

- `src/utils/signature.ts`
  - Add `calculateYParity(recoveryId): 0 | 1` for typed transactions.
  - Note in `calculateV` that it is legacy-only.
- `src/kms/signer.ts`, `src/gcp/signer.ts`
  - Branch on `getTransactionType(transaction)`:
    - `'legacy'` → pass `{ r, s, v }` as the second `serializer` argument (EIP-155 when `chainId`, pre-EIP-155 otherwise).
    - typed → pass `{ r, s, yParity }` as the second `serializer` argument.
  - Strip `yParity` from the unsigned payload alongside `r/s/v` so the hash is deterministic.
- `src/integration.test.ts` (new)
  - End-to-end `recoverTransactionAddress` round trip.
  - The mocked KMS client is wired to a real `secp256k1` keypair via `viem/accounts.privateKeyToAccount` + `viem/accounts.sign`, with an inline DER encoder so the production DER parse path runs unchanged.
  - Covers EIP-1559, EIP-2930, EIP-155 legacy and pre-EIP-155 legacy for both `KmsSigner` and `GcpSigner`.

## Verification

- `pnpm test:run` → **182 / 182** passing (7 new integration tests).
- `pnpm type-check` → clean.
- `pnpm lint` → clean (one pre-existing biome schema-version info note).
- `pnpm build` → clean.

The 7 new round-trip tests exercise the exact failure scenario from the issue's `repro-yparity.mjs` (EIP-1559 on Sepolia `chainId = 11155111`) and would have failed against `main`:
- Typed: previously produced the wrong `yParity` → `recoverTransactionAddress` returned a different address.
- Legacy: previously produced an unsigned RLP (no `r/s/v`) → `recoverTransactionAddress` threw.

## Notes

- The legacy path keeps EIP-155 `v` to preserve backwards compatibility for legacy callers and to match the `chainId` they specified.
- No public API breaking changes. `KmsSigner` / `GcpSigner` / `toKmsAccount` / `toGcpKmsAccount` signatures are unchanged.
- `calculateV` is preserved (still exported and tested) and now also used internally by the legacy branch.
