### PR TITLE
test(signer): add issue #102 regression coverage for EIP-1559 yParity

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -330,3 +330,108 @@ describe('signTransaction yParity round-trip (issue #98)', () => {
 		});
 	});
 });
+
+// Issue #102 reported a ~50% failure rate for EIP-1559 transactions: whenever
+// the recovery id happened to be 0 the previous code fed an EIP-155 v
+// (e.g. v=37 on mainnet) into viem's typed serializer, which silently fell
+// back to `yParity = 1` and produced a signature that recovered to the wrong
+// address. We iterate over many random keys so both recoveryId values are
+// statistically guaranteed to be exercised in a single test run; without the
+// fix shipped in #111 the recoveryId=0 iterations would fail.
+const STATISTICAL_ITERATIONS = 25;
+
+describe('signTransaction yParity round-trip (issue #102 regression)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('KmsSigner: EIP-1559 round-trips across many keys, covering both yParity 0 and 1', async () => {
+		// #given
+		const observedYParities = new Set<number>();
+
+		for (let i = 0; i < STATISTICAL_ITERATIONS; i++) {
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(KmsClient), privateKey);
+			const signer = new KmsSigner({
+				region: 'us-east-1',
+				keyId: 'test-key',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip1559',
+				chainId: 1,
+				nonce: i,
+				maxFeePerGas: 12_090_378n,
+				maxPriorityFeePerGas: 1_000_000n,
+				gas: 59_850n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				data: '0x',
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip1559');
+			expect(parsed.yParity === 0 || parsed.yParity === 1).toBe(true);
+			observedYParities.add(parsed.yParity as number);
+		}
+
+		// Statistical guarantee: with 25 random keys the probability of seeing
+		// only one yParity value is 2 * 2^-25 ≈ 6e-8.
+		expect(observedYParities.has(0)).toBe(true);
+		expect(observedYParities.has(1)).toBe(true);
+	});
+
+	test('GcpSigner: EIP-1559 round-trips across many keys, covering both yParity 0 and 1', async () => {
+		// #given
+		const observedYParities = new Set<number>();
+
+		for (let i = 0; i < STATISTICAL_ITERATIONS; i++) {
+			const privateKey = generatePrivateKey();
+			const account = setupRealCryptoMock(vi.mocked(GcpClient), privateKey);
+			const signer = new GcpSigner({
+				projectId: 'test-project',
+				locationId: 'global',
+				keyRingId: 'test-keyring',
+				keyId: 'test-key',
+				keyVersion: '1',
+			});
+			const transaction: TransactionSerializable = {
+				type: 'eip1559',
+				chainId: 1,
+				nonce: i,
+				maxFeePerGas: 12_090_378n,
+				maxPriorityFeePerGas: 1_000_000n,
+				gas: 59_850n,
+				to: getAddress('0x6f394dd59f2301340efb711c97b0bb2711915058'),
+				value: 0n,
+				data: '0x',
+			};
+
+			// #when
+			const serialized = await signer.signTransaction(transaction);
+
+			// #then
+			const recovered = await recoverTransactionAddress({
+				serializedTransaction: serialized,
+			});
+			expect(recovered).toBe(account.address);
+
+			const parsed = parseTransaction(serialized);
+			expect(parsed.type).toBe('eip1559');
+			expect(parsed.yParity === 0 || parsed.yParity === 1).toBe(true);
+			observedYParities.add(parsed.yParity as number);
+		}
+
+		// Statistical guarantee: same probability as the KmsSigner case.
+		expect(observedYParities.has(0)).toBe(true);
+		expect(observedYParities.has(1)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #102.

Issue #102 reports the same root cause as #98 (a typed transaction signed by `KmsSigner` / `GcpSigner` was carrying an EIP-155 `v` instead of `yParity`, recovering to the wrong address ~50% of the time). The fix shipped in #111 already addresses both at the code level by emitting `yParity` for EIP-2930 / EIP-1559 / EIP-4844 / EIP-7702 transactions.

This PR adds an explicit **statistical regression test** that targets the exact failure mode #102 described — a missing recoveryId=0 case — so the bug cannot silently come back and the issue can be closed with verifiable coverage.

## Why an extra test?

The existing `src/integration.test.ts` round-trip suite added in #111 uses a single random key per case. That means a future regression that only affects the recoveryId=0 branch could pass on a lucky run.

#102 explicitly called out the ~50% asymmetry: `recoveryId = 0` was the failing case, because the old code produced `v = chainId * 2 + 35` (e.g. `v = 37` on mainnet) and viem's typed serializer fell back to `yParity = 1`.

## Changes

- `src/integration.test.ts` — new describe `signTransaction yParity round-trip (issue #102 regression)`:
  - **`KmsSigner`** and **`GcpSigner`** each run 25 random keys against an EIP-1559 transaction.
  - Every serialized transaction must round-trip through `recoverTransactionAddress` back to the original account address.
  - The set of observed `yParity` values must contain both `0` and `1`.
- With 25 random keys the probability of seeing only one yParity value is `2 * 2^-25 ≈ 6 × 10^-8`, so any future regression that breaks the recoveryId=0 branch will fail almost deterministically.

No production code changes.

## Verification

- `pnpm test:run` → **184 / 184** passing (2 new regression tests).
- `pnpm type-check` → clean.
- `pnpm lint` → clean (one pre-existing biome schema-version info note).
- **Bug-detection check**: temporarily reverted `src/kms/signer.ts` and `src/gcp/signer.ts` to the pre-#111 state on this branch — both new tests fail with the wrong recovered address; restoring the fix turns them green. Confirms the tests actually catch the regression they describe.
