### PR TITLE
fix(build): emit .js extensions in relative imports for ESM compatibility

### DIFF
--- a/examples/gcp-send-transaction.ts
+++ b/examples/gcp-send-transaction.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { createWalletClient, http } from 'viem';
 import { sepolia } from 'viem/chains';
-import { GcpSigner, toGcpKmsAccount } from '../src';
+import { GcpSigner, toGcpKmsAccount } from '../src/index.js';
 
 async function main() {
 	// Validate environment variables

--- a/examples/gcp-sign-message.ts
+++ b/examples/gcp-sign-message.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { GcpSigner, toGcpKmsAccount } from '../src';
+import { GcpSigner, toGcpKmsAccount } from '../src/index.js';
 
 async function main() {
 	// Validate environment variables

--- a/examples/send-transaction.ts
+++ b/examples/send-transaction.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { createWalletClient, http } from 'viem';
 import { sepolia } from 'viem/chains';
-import { KmsSigner, toKmsAccount } from '../src';
+import { KmsSigner, toKmsAccount } from '../src/index.js';
 
 async function main() {
 	// Validate environment variables

--- a/examples/sign-message.ts
+++ b/examples/sign-message.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { KmsSigner, toKmsAccount } from '../src';
+import { KmsSigner, toKmsAccount } from '../src/index.js';
 
 async function main() {
 	// Validate environment variables

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,7 +1,7 @@
 import type { LocalAccount } from 'viem';
 import { toAccount } from 'viem/accounts';
-import type { GcpSigner } from './gcp/signer';
-import type { KmsSigner } from './kms/signer';
+import type { GcpSigner } from './gcp/signer.js';
+import type { KmsSigner } from './kms/signer.js';
 
 /**
  * Create a viem Account from KmsSigner.

--- a/src/errors/index.test.ts
+++ b/src/errors/index.test.ts
@@ -5,7 +5,7 @@ import {
 	KmsSignerError,
 	RecoveryIdCalculationError,
 	SignatureNormalizationError,
-} from './index';
+} from './index.js';
 
 describe('KmsSignerError', () => {
 	test('should create error with correct name and message', () => {

--- a/src/gcp/client.test.ts
+++ b/src/gcp/client.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { KmsClientError } from '../errors';
-import type { GcpKmsConfig } from '../types';
-import { GcpClient } from './client';
+import { KmsClientError } from '../errors/index.js';
+import type { GcpKmsConfig } from '../types/index.js';
+import { GcpClient } from './client.js';
 
 // Mock @google-cloud/kms SDK
 vi.mock('@google-cloud/kms', () => ({

--- a/src/gcp/client.ts
+++ b/src/gcp/client.ts
@@ -1,6 +1,6 @@
 import { KeyManagementServiceClient } from '@google-cloud/kms';
-import { KmsClientError } from '../errors';
-import type { GcpKmsConfig } from '../types';
+import { KmsClientError } from '../errors/index.js';
+import type { GcpKmsConfig } from '../types/index.js';
 
 /**
  * GcpClient wraps GCP KMS SDK operations for key management and signing.

--- a/src/gcp/signer.test.ts
+++ b/src/gcp/signer.test.ts
@@ -1,9 +1,9 @@
 import type { TransactionSerializable } from 'viem';
 import { getAddress } from 'viem';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import * as signatureUtils from '../utils/signature';
-import { GcpClient } from './client';
-import { GcpSigner } from './signer';
+import * as signatureUtils from '../utils/signature.js';
+import { GcpClient } from './client.js';
+import { GcpSigner } from './signer.js';
 
 // Valid secp256k1 DER public key (65-byte uncompressed key)
 const MOCK_DER_PUBLIC_KEY = new Uint8Array([
@@ -51,7 +51,7 @@ const MOCK_DER_SIGNATURE = new Uint8Array([
 ]);
 
 // Mock GcpClient
-vi.mock('./client', () => {
+vi.mock('./client.js', () => {
 	return {
 		GcpClient: vi.fn(),
 	};

--- a/src/gcp/signer.ts
+++ b/src/gcp/signer.ts
@@ -16,17 +16,20 @@ import {
 	serializeTransaction,
 	toHex,
 } from 'viem';
-import type { GcpKmsConfig } from '../types';
-import { extractPublicKeyFromDer, publicKeyToAddress } from '../utils/address';
-import { parseDerSignature } from '../utils/der';
+import type { GcpKmsConfig } from '../types/index.js';
+import {
+	extractPublicKeyFromDer,
+	publicKeyToAddress,
+} from '../utils/address.js';
+import { parseDerSignature } from '../utils/der.js';
 import {
 	calculateRecoveryId,
 	calculateV,
 	calculateYParity,
 	normalizeS,
 	uint8ArrayToBigInt,
-} from '../utils/signature';
-import { GcpClient } from './client';
+} from '../utils/signature.js';
+import { GcpClient } from './client.js';
 
 /**
  * GcpSigner provides Ethereum signing capabilities using GCP KMS.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 // Re-export commonly used viem types for convenience
 export type { Address, Hex } from 'viem';
-export { toGcpKmsAccount, toKmsAccount } from './account';
+export { toGcpKmsAccount, toKmsAccount } from './account.js';
 // Errors
 export {
 	DerParsingError,
@@ -10,13 +10,13 @@ export {
 	KmsSignerError,
 	RecoveryIdCalculationError,
 	SignatureNormalizationError,
-} from './errors';
-export { GcpSigner } from './gcp/signer';
-export { KmsSigner } from './kms/signer';
+} from './errors/index.js';
+export { GcpSigner } from './gcp/signer.js';
+export { KmsSigner } from './kms/signer.js';
 // Types
 export type {
 	DerSignature,
 	GcpKmsConfig,
 	KmsConfig,
 	SignatureData,
-} from './types';
+} from './types/index.js';

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -11,13 +11,13 @@ import {
 	sign as viemSign,
 } from 'viem/accounts';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { GcpClient } from './gcp/client';
-import { GcpSigner } from './gcp/signer';
-import { KmsClient } from './kms/client';
-import { KmsSigner } from './kms/signer';
+import { GcpClient } from './gcp/client.js';
+import { GcpSigner } from './gcp/signer.js';
+import { KmsClient } from './kms/client.js';
+import { KmsSigner } from './kms/signer.js';
 
-vi.mock('./kms/client', () => ({ KmsClient: vi.fn() }));
-vi.mock('./gcp/client', () => ({ GcpClient: vi.fn() }));
+vi.mock('./kms/client.js', () => ({ KmsClient: vi.fn() }));
+vi.mock('./gcp/client.js', () => ({ GcpClient: vi.fn() }));
 
 // ASN.1 DER encoder for a secp256k1 ECDSA signature (SEQUENCE { INTEGER r, INTEGER s }).
 // Mirrors what AWS/GCP KMS returns so tests can feed real viem-produced signatures

--- a/src/kms/client.ts
+++ b/src/kms/client.ts
@@ -5,8 +5,8 @@ import {
 	SignCommand,
 	SigningAlgorithmSpec,
 } from '@aws-sdk/client-kms';
-import { KmsClientError } from '../errors';
-import type { KmsConfig } from '../types';
+import { KmsClientError } from '../errors/index.js';
+import type { KmsConfig } from '../types/index.js';
 
 /**
  * KmsClient wraps AWS KMS SDK operations for key management and signing.

--- a/src/kms/signer.test.ts
+++ b/src/kms/signer.test.ts
@@ -1,9 +1,9 @@
 import type { TransactionSerializable } from 'viem';
 import { getAddress } from 'viem';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import * as signatureUtils from '../utils/signature';
-import { KmsClient } from './client';
-import { KmsSigner } from './signer';
+import * as signatureUtils from '../utils/signature.js';
+import { KmsClient } from './client.js';
+import { KmsSigner } from './signer.js';
 
 // Valid secp256k1 DER public key (65-byte uncompressed key)
 const MOCK_DER_PUBLIC_KEY = new Uint8Array([
@@ -51,7 +51,7 @@ const MOCK_DER_SIGNATURE = new Uint8Array([
 ]);
 
 // Mock KmsClient
-vi.mock('./client', () => {
+vi.mock('./client.js', () => {
 	return {
 		KmsClient: vi.fn(),
 	};

--- a/src/kms/signer.ts
+++ b/src/kms/signer.ts
@@ -16,17 +16,20 @@ import {
 	serializeTransaction,
 	toHex,
 } from 'viem';
-import type { KmsConfig } from '../types';
-import { extractPublicKeyFromDer, publicKeyToAddress } from '../utils/address';
-import { parseDerSignature } from '../utils/der';
+import type { KmsConfig } from '../types/index.js';
+import {
+	extractPublicKeyFromDer,
+	publicKeyToAddress,
+} from '../utils/address.js';
+import { parseDerSignature } from '../utils/der.js';
 import {
 	calculateRecoveryId,
 	calculateV,
 	calculateYParity,
 	normalizeS,
 	uint8ArrayToBigInt,
-} from '../utils/signature';
-import { KmsClient } from './client';
+} from '../utils/signature.js';
+import { KmsClient } from './client.js';
 
 /**
  * KmsSigner provides Ethereum signing capabilities using AWS KMS.

--- a/src/utils/address.test.ts
+++ b/src/utils/address.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { DerParsingError } from '../errors';
-import { extractPublicKeyFromDer, publicKeyToAddress } from './address';
+import { DerParsingError } from '../errors/index.js';
+import { extractPublicKeyFromDer, publicKeyToAddress } from './address.js';
 
 describe('extractPublicKeyFromDer', () => {
 	test('should extract 65-byte public key from DER-encoded bytes', () => {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,5 +1,5 @@
 import { type Address, keccak256, toHex } from 'viem';
-import { DerParsingError } from '../errors';
+import { DerParsingError } from '../errors/index.js';
 
 /**
  * Extract uncompressed public key from DER-encoded SubjectPublicKeyInfo

--- a/src/utils/der.test.ts
+++ b/src/utils/der.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { DerParsingError } from '../errors';
-import { parseDerSignature } from './der';
+import { DerParsingError } from '../errors/index.js';
+import { parseDerSignature } from './der.js';
 
 describe('parseDerSignature', () => {
 	test('should parse valid DER signature with 32-byte r and s', () => {

--- a/src/utils/der.ts
+++ b/src/utils/der.ts
@@ -1,5 +1,5 @@
-import { DerParsingError } from '../errors';
-import type { DerSignature } from '../types';
+import { DerParsingError } from '../errors/index.js';
+import type { DerSignature } from '../types/index.js';
 
 /**
  * Parse DER-encoded ECDSA signature into r and s components

--- a/src/utils/signature.test.ts
+++ b/src/utils/signature.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
 	RecoveryIdCalculationError,
 	SignatureNormalizationError,
-} from '../errors';
+} from '../errors/index.js';
 import {
 	calculateRecoveryId,
 	calculateV,
@@ -12,7 +12,7 @@ import {
 	SECP256K1_N,
 	SECP256K1_N_HALF,
 	uint8ArrayToBigInt,
-} from './signature';
+} from './signature.js';
 
 describe('normalizeS', () => {
 	test('should normalize s when s > n/2', () => {

--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -3,8 +3,8 @@ import { fromHex, recoverPublicKey } from 'viem';
 import {
 	RecoveryIdCalculationError,
 	SignatureNormalizationError,
-} from '../errors';
-import { publicKeyToAddress } from './address';
+} from '../errors/index.js';
+import { publicKeyToAddress } from './address.js';
 
 /**
  * secp256k1 curve order (n)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,8 @@
 		"types": ["node", "vitest/globals"],
 
 		// Modules
-		"module": "ESNext",
-		"moduleResolution": "bundler",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"moduleDetection": "force",
 		"resolveJsonModule": true,
 


### PR DESCRIPTION
## Summary

Fixes #99 — restores ESM compatibility of the published package.

`package.json` declares `"type": "module"`, but the previous TypeScript config (`moduleResolution: "bundler"`) emitted extensionless relative imports into `dist/`:

```js
export { toGcpKmsAccount, toKmsAccount } from './account';
```

Node.js's ESM loader rejects this with `ERR_MODULE_NOT_FOUND`, so any ESM consumer of `evm-kms-signer` would fail at import time:

```
Error: Cannot find module '.../node_modules/evm-kms-signer/dist/account'
imported from .../node_modules/evm-kms-signer/dist/index.js
Expected: Imports should use .js extensions
```

## Changes

- **`tsconfig.json`**: Switched `module` and `moduleResolution` from `ESNext` / `bundler` to `NodeNext`. This makes the TypeScript compiler enforce `.js` extensions on relative imports and preserves them in the emit.
- **All source imports**: Added explicit `.js` extensions to every relative import in `src/`. Directory-style imports such as `'../errors'` were rewritten to `'../errors/index.js'` since `NodeNext` does not perform `index` resolution.
- **Tests**: Updated `vi.mock(...)` paths to match the new `.js`-suffixed imports so the mocks resolve to the same module identity.
- **Examples**: Updated `'../src'` → `'../src/index.js'` for the same reason.

After the change, `dist/index.js` now emits the correct ESM-compliant form:

```js
export { toGcpKmsAccount, toKmsAccount } from './account.js';
export { DerParsingError, /* ... */ } from './errors/index.js';
export { GcpSigner } from './gcp/signer.js';
export { KmsSigner } from './kms/signer.js';
```

## Verification

- `pnpm build` — clean compile, dist now contains `.js`-suffixed relative imports throughout.
- `pnpm type-check` — passes.
- `pnpm lint` — passes (the lone info note about Biome schema version is pre-existing on `main`, unrelated to this change).
- `pnpm test:run` — **184 / 184 tests pass across 8 files**.
- ESM smoke test against the built `dist/` (simulating a downstream ESM consumer):
  ```
  node --input-type=module -e "import('./dist/index.js').then(m => console.log(Object.keys(m)))"
  ```
  resolves successfully and exports all symbols (`KmsSigner`, `GcpSigner`, `toKmsAccount`, `toGcpKmsAccount`, error classes, types).

## Notes

- No runtime behavior changes — purely a module-resolution / emit-format fix.
- `NodeNext` is the recommended resolution for ESM packages targeting Node.js, and matches the runtime that consumers will use.
- This aligns with the suggested fix from the issue reporter (@mdesousa).

Closes #99
